### PR TITLE
CRUD on Documentos was fully implemented

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,11 @@
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-mongodb</artifactId>
         </dependency>
         <dependency>

--- a/src/main/java/com/dirac/aplicacioningsoftfinal/Exception/CreationException.java
+++ b/src/main/java/com/dirac/aplicacioningsoftfinal/Exception/CreationException.java
@@ -1,0 +1,9 @@
+package com.dirac.aplicacioningsoftfinal.Exception;
+
+public class CreationException extends RuntimeException{
+
+    public CreationException(String collection){
+        super("Error al intentar crear un objeto de la colección " +  collection);
+    }
+
+}

--- a/src/main/java/com/dirac/aplicacioningsoftfinal/Exception/DeleteException.java
+++ b/src/main/java/com/dirac/aplicacioningsoftfinal/Exception/DeleteException.java
@@ -1,0 +1,9 @@
+package com.dirac.aplicacioningsoftfinal.Exception;
+
+public class DeleteException extends RuntimeException{
+    
+    public DeleteException(String collection){
+        super("Error al intentar eliminar la colección: " + collection);
+    }
+    
+}

--- a/src/main/java/com/dirac/aplicacioningsoftfinal/Exception/InvalidVisibilityException.java
+++ b/src/main/java/com/dirac/aplicacioningsoftfinal/Exception/InvalidVisibilityException.java
@@ -1,0 +1,12 @@
+package com.dirac.aplicacioningsoftfinal.Exception;
+
+public class InvalidVisibilityException extends RuntimeException{
+    public InvalidVisibilityException(String message ){
+        super(message);
+    }
+
+    public InvalidVisibilityException(){
+        super("La visibilidad está privada así que no se puede acceder a ella");
+    }
+
+}

--- a/src/main/java/com/dirac/aplicacioningsoftfinal/Exception/UpdateException.java
+++ b/src/main/java/com/dirac/aplicacioningsoftfinal/Exception/UpdateException.java
@@ -1,0 +1,9 @@
+package com.dirac.aplicacioningsoftfinal.Exception;
+
+public class UpdateException extends RuntimeException{
+    
+    public UpdateException(String collection){
+        super("Error al intentar actualizar la colección: " + collection);
+    }
+
+}

--- a/src/main/java/com/dirac/aplicacioningsoftfinal/Model/CategoriaModel.java
+++ b/src/main/java/com/dirac/aplicacioningsoftfinal/Model/CategoriaModel.java
@@ -1,7 +1,10 @@
 package com.dirac.aplicacioningsoftfinal.Model;
 
+import org.bson.types.ObjectId;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
@@ -17,7 +20,13 @@ import java.util.Map;
 
 public class CategoriaModel {
     @Id
-    private String _id;
+    private ObjectId _id;
+
+    @JsonProperty("_id")
+    public String get_idAString() {
+        return _id != null ? _id.toHexString() : null;
+    }
+
     private String nombre;
     private String descripcion;
     private List<Map<String, String>> subcategorias;

--- a/src/main/java/com/dirac/aplicacioningsoftfinal/Model/DocumentoModel.java
+++ b/src/main/java/com/dirac/aplicacioningsoftfinal/Model/DocumentoModel.java
@@ -3,8 +3,12 @@ package com.dirac.aplicacioningsoftfinal.Model;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import org.bson.types.ObjectId;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Date;
 import java.util.List;
@@ -16,7 +20,13 @@ import java.util.List;
 public class DocumentoModel {
 
     @Id
-    private String _id;
+    private ObjectId _id;
+
+    @JsonProperty("_id")
+    public String getIdAsString(){
+        return _id != null ? _id.toHexString() : null;
+    }
+
     private String titulo;
     private String descripcion;
     private String visibilidad;
@@ -29,21 +39,35 @@ public class DocumentoModel {
     private DatosComputados datosComputados;
     private String idioma;
 
+    @AllArgsConstructor
     @Data
     public static class CategoriasEmbebidas {
-        private String categoriaId;
+        private ObjectId categoriaId;
+
+        @JsonProperty("categoriaId")
+        public String getCategoriaIdAsString() {
+            return categoriaId != null ? categoriaId.toHexString() : null;
+        }
+    
         public String nombre;
     }
 
+    @AllArgsConstructor
     @Data
     public static class Autores {
-        private String usuarioId;
-        private Boolean estaRegistrado;
+        private ObjectId usuarioId; 
+
+        @JsonProperty("usuarioId")
+        public String getUsuarioIdAsString() {
+            return usuarioId != null ? usuarioId.toHexString() : null;
+        }
+    
         private String rol;
         private String username;
         private String nombre;
     }
 
+    @AllArgsConstructor
     @Data
     public static class DatosComputados {
         private long descargasTotales;
@@ -51,9 +75,16 @@ public class DocumentoModel {
         private long comentariosTotales;
     }
 
+    @AllArgsConstructor
     @Data
     public static class Valoracion {
-        private String usuarioId;
+        private ObjectId usuarioId; 
+
+        @JsonProperty("usuarioId")
+        public String getUsuarioIdAsString() {
+            return usuarioId != null ? usuarioId.toHexString() : null;
+        }
+    
         private Date fechaCreacion;
         private double puntuacion;
         private String comentario;

--- a/src/main/java/com/dirac/aplicacioningsoftfinal/Model/UsuarioModel.java
+++ b/src/main/java/com/dirac/aplicacioningsoftfinal/Model/UsuarioModel.java
@@ -1,7 +1,10 @@
 package com.dirac.aplicacioningsoftfinal.Model;
 
+import org.bson.types.ObjectId;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
@@ -18,7 +21,13 @@ import java.util.Map;
 
 public class UsuarioModel {
     @Id
-    private String _id;
+    private ObjectId _id;
+
+    @JsonProperty("_id")
+    public String get_idAString() {
+        return _id != null ? _id.toHexString() : null;
+    }
+
     private String username;
     private String email;
     private List<Map<String, String>> credenciales;

--- a/src/main/java/com/dirac/aplicacioningsoftfinal/Repository/IDocumentoRepository.java
+++ b/src/main/java/com/dirac/aplicacioningsoftfinal/Repository/IDocumentoRepository.java
@@ -16,7 +16,7 @@ import java.util.Optional;
 public interface IDocumentoRepository extends MongoRepository<DocumentoModel, ObjectId> {
 
     @Query(value = "{ '_id': ?0 }", fields = "{'_id': 0, 'urlArchivo': 1, 'visibilidad': 1}")
-    Optional<UrlDTO> findUrlArchivoById(String id);
+    Optional<UrlDTO> findUrlArchivoById(ObjectId id);
 
     @Query("{_id : '?0'}")
     Optional<DocumentoModel> findDocumentByID(ObjectId _id);

--- a/src/main/java/com/dirac/aplicacioningsoftfinal/Service/IDocumentoService.java
+++ b/src/main/java/com/dirac/aplicacioningsoftfinal/Service/IDocumentoService.java
@@ -5,6 +5,8 @@ import com.dirac.aplicacioningsoftfinal.DTO.BusquedaOrdenarFiltrarDTO;
 import com.dirac.aplicacioningsoftfinal.DTO.UrlDTO;
 import com.dirac.aplicacioningsoftfinal.Model.DocumentoModel;
 import org.bson.types.ObjectId;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.servlet.view.RedirectView;
 
 import java.util.Date;
 import java.util.List;
@@ -12,15 +14,35 @@ import java.util.List;
 public interface IDocumentoService {
 
     DocumentoModel getDocument(ObjectId _id);
-    DocumentoModel getDocumentByTitle(String titulo);
-    List<DocumentoModel> getDocumentsByKeyword(List<String> keywords);
-    List<DocumentoModel> getDocumentsByFechaSubida (Date fechaSubida);
-    List <DocumentoModel> getDocumentsByCategoriaNombre(String nombreCategoria);
-    List <DocumentoModel> getDocumentsByAutorUsuarioname(String nombreAutor);
-    List <DocumentoModel> getDocumentsByLenguage(String idioma);
-    List<DocumentoModel> busquedaFiltroDocumentos(BusquedaFiltroDTO entrada);
-    List<DocumentoModel> busquedaOrdenada(BusquedaOrdenarFiltrarDTO entrada);
-    UrlDTO recuperarUrlById(String id);
 
+    DocumentoModel getDocumentByTitle(String titulo);
+
+    List<DocumentoModel> getDocumentsByKeyword(List<String> keywords);
+
+    List<DocumentoModel> getDocumentsByFechaSubida(Date fechaSubida);
+
+    List<DocumentoModel> getDocumentsByCategoriaNombre(String nombreCategoria);
+
+    List<DocumentoModel> getDocumentsByAutorUsuarioname(String nombreAutor);
+
+    List<DocumentoModel> getDocumentsByLenguage(String idioma);
+
+    String createDocument(DocumentoModel documento);
+
+    String updateDocument(ObjectId idDocumentoAntiguo, DocumentoModel documentoNuevo);
+
+    String deleteDocument(ObjectId _id);
+
+    List<DocumentoModel> busquedaFiltroDocumentos(BusquedaFiltroDTO entrada);
+
+    List<DocumentoModel> busquedaOrdenada(BusquedaOrdenarFiltrarDTO entrada);
+
+    UrlDTO recuperarUrlById(ObjectId id);
+
+    RedirectView downloadDocumentByTitle(String titulo) throws Exception;
+
+    ResponseEntity<?> downloadDocumentById(ObjectId id) throws Exception;
+
+    void updateDownloadStats(DocumentoModel document);
 
 }


### PR DESCRIPTION
El CRUD para Documentos fue implementado en su totailidad.

-Cuando una persona Descarga el documento bien sea por **Título** o **id**, en la base de datos se actualiza y las descargasTotales de ese documento aumenta en (1).

-Se separó la lógica del negocio añadiendole nuevas excepciones como "CreateException" , "UpdateException", "DeleteException" para cada operación. 

**NOTA: Los modelos y DTO's fueron modificados para que tuviesen lo siguiente, es una anotación que permite mapear los ObjectsId's correctamente y en caso tal, de necesitar hacer una consulta (operacion READ) entonces se convierte a String(hexadecimal)**

![image](https://github.com/user-attachments/assets/6de683ee-444c-480b-b75f-f611c1b8e217)

 