### PR TITLE
Actualización sobre JwtTokenVerifier

### DIFF
--- a/API/AplicacionIngSoftFinal/src/main/java/com/dirac/aplicacioningsoftfinal/Security/JWT/JwtTokenVerifier.java
+++ b/API/AplicacionIngSoftFinal/src/main/java/com/dirac/aplicacioningsoftfinal/Security/JWT/JwtTokenVerifier.java
@@ -41,6 +41,7 @@ public class JwtTokenVerifier extends OncePerRequestFilter {
         if (Strings.isNullOrEmpty(authorizationHeader) || !authorizationHeader.startsWith(jwtConfigurationVariables.getTokenPrefix())) {
 
             filterChain.doFilter(request, response);
+            return;
 
         }
 


### PR DESCRIPTION
Se agregó un return que faltaba para que no entrara a la funcionalidad cuando no se agrega un token de autorización.